### PR TITLE
/api/v1/questions/final - allow only checking final answer

### DIFF
--- a/CodeChallenge/api/questions.py
+++ b/CodeChallenge/api/questions.py
@@ -228,6 +228,10 @@ def answer_eval():
 
     correct = str_cmp(eval_output, q.answer)
 
+    if request.json.get("checkOnly", False):
+        return jsonify(correct=correct,
+                       status="success")
+
     ans = Answer.query.filter_by(user_id=user.id, question_id=q.id).first()
 
     if ans is None:


### PR DESCRIPTION
if a boolean 'checkOnly' property is present in the JSON body
and is true, the endpoint will respond with correct/incorrect
but will not record the answer in the database.